### PR TITLE
Insert CSS via link element instead of importing

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,9 +1,4 @@
 import * as data from './portfolio_entries.json' with {type: 'json'};
-import style from './style.css' with {type: 'css'};
-
-const link = document.createElement('link');
-link.rel = 'stylesheet';
-link.href = './style.css';
 
 window.addEventListener('scroll', () => {
   document.body.style.setProperty('--scroll', Math.min(0.9999, window.scrollY / window.innerHeight * 2))
@@ -34,9 +29,11 @@ class PortfolioEntry extends HTMLElement {
 
     const shadowRoot = this.attachShadow({mode: "open"});
     shadowRoot.appendChild(document.importNode(templateContent, true));
-
-    shadowRoot.adoptedStyleSheets = [style];
-    // shadowRoot.appendChild(link);
+    
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = './style.css';
+    shadowRoot.appendChild(link);
   }
 }
 


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with#browser_compatibility), `import ... with {type: 'css'}` is not supported by Safari. So, that has been removed, and inserted portfolio entries are given styles through the insertion of a `<link>` element.