### PR TITLE
Improve overlaying of navbar on narrow screens

### DIFF
--- a/achievements.js
+++ b/achievements.js
@@ -7,6 +7,11 @@ let achievementsPane = document.querySelector("#achievements-pane")
 let achievementsIcon = document.querySelector("#achievements-icon")
 let soundEffect = new Audio("./sounds/tada.mp3")
 
+let searchParams = new URLSearchParams(window.location.search)
+if (searchParams.get("withAchievement") === "true") {
+  earnAchievement("visitedWithAchievement")
+}
+
 achievementsButton.addEventListener("click", () => {
   open = !open
   if (open) {

--- a/achievements.js
+++ b/achievements.js
@@ -21,7 +21,12 @@ achievementsButton.addEventListener("click", () => {
   }
 })
 
-makePositionSticky(achievementsPane, 0.125 * document.documentElement.clientHeight - 20, "calc(12.5vh - var(--pane-margin))", () => 0.125 * document.documentElement.clientHeight - 20)
+makePositionSticky(
+  achievementsPane,
+  0.125 * document.documentElement.clientHeight - getComputedStyle(achievementsPane).getPropertyValue('--pane-margin'),
+  "calc(12.5vh - var(--pane-margin))",
+  () => 0.125 * document.documentElement.clientHeight - getComputedStyle(achievementsPane).getPropertyValue('--pane-margin')
+)
 
 const getAchievements = () => {
   let achievements = localStorage.getItem("achievements")

--- a/achievements.js
+++ b/achievements.js
@@ -21,7 +21,7 @@ achievementsButton.addEventListener("click", () => {
   }
 })
 
-makePositionSticky(achievementsPane, 0.125 * document.documentElement.clientHeight - 20, "calc(12.5vh - var(--pane-margin))")
+makePositionSticky(achievementsPane, 0.125 * document.documentElement.clientHeight - 20, "calc(12.5vh - var(--pane-margin))", () => 0.125 * document.documentElement.clientHeight - 20)
 
 const getAchievements = () => {
   let achievements = localStorage.getItem("achievements")

--- a/achievements.js
+++ b/achievements.js
@@ -8,11 +8,6 @@ let achievementsPane = document.querySelector("#achievements-pane")
 let achievementsIcon = document.querySelector("#achievements-icon")
 let soundEffect = new Audio("./sounds/tada.mp3")
 
-let searchParams = new URLSearchParams(window.location.search)
-if (searchParams.get("withAchievement") === "true") {
-  earnAchievement("visitedWithAchievement")
-}
-
 achievementsButton.addEventListener("click", () => {
   open = !open
   if (open) {
@@ -204,3 +199,8 @@ requestAnimationFrame(markTopRowAchievements)
 
 
 window.addEventListener("resize", markTopRowAchievements)
+
+let searchParams = new URLSearchParams(window.location.search)
+if (searchParams.get("withAchievement") === "true") {
+  earnAchievement("visitedWithAchievement")
+}

--- a/achievements.js
+++ b/achievements.js
@@ -1,5 +1,6 @@
 import {StandardTemplate} from "./standardTemplate.js"
 import * as achievementsData from "./achievements.json" with {type: 'json'}
+import {makePositionSticky} from "./stickyPosition.js"
 
 let open = false
 let achievementsButton = document.querySelector("#achievements-open-button")
@@ -25,18 +26,7 @@ achievementsButton.addEventListener("click", () => {
   }
 })
 
-window.addEventListener('scroll', () => {
-  let scrollTop = window.scrollY
-  // Top of element is the parent element's top, plus the element's height, since the parent's height is 0 because the element is outside the normal flow
-  let elementTop = achievementsPane.parentElement.getBoundingClientRect().top + achievementsPane.offsetHeight
-  if (elementTop > scrollTop) {
-    achievementsPane.style.position = "absolute"
-    achievementsPane.style.top = "auto"
-  } else {
-    achievementsPane.style.position = "fixed"
-    achievementsPane.style.top = "calc(12.5vh - var(--pane-margin))"
-  }
-}, false)
+makePositionSticky(achievementsPane, 0.125 * document.documentElement.clientHeight - 20, "calc(12.5vh - var(--pane-margin))")
 
 const getAchievements = () => {
   let achievements = localStorage.getItem("achievements")

--- a/achievements.js
+++ b/achievements.js
@@ -23,9 +23,9 @@ achievementsButton.addEventListener("click", () => {
 
 makePositionSticky(
   achievementsPane,
-  0.125 * document.documentElement.clientHeight - getComputedStyle(achievementsPane).getPropertyValue('--pane-margin'),
+  0.125 * document.documentElement.clientHeight - parseFloat(getComputedStyle(achievementsPane).getPropertyValue('--pane-margin')),
   "calc(12.5vh - var(--pane-margin))",
-  () => 0.125 * document.documentElement.clientHeight - getComputedStyle(achievementsPane).getPropertyValue('--pane-margin')
+  () => 0.125 * document.documentElement.clientHeight - parseFloat(getComputedStyle(achievementsPane).getPropertyValue('--pane-margin'))
 )
 
 const getAchievements = () => {

--- a/index.html
+++ b/index.html
@@ -131,6 +131,8 @@
 
   </nav>
 
+  <div id="post-nav-spacer"></div>
+
   <main id="#portfolio">
     <div id="collaborative-projects">
       <h2>projects i have worked on</h2>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Leandru Martin's Portfolio</title>
   <link rel="stylesheet" href="style.css"/>
+  <link rel="icon" type="image/x-icon" href="/images/favicon_pen.png">
+
   <script defer type="module" src="script.js"></script>
   <script defer type="module" src="achievements.js"></script>
-  <link rel="icon" type="image/x-icon" href="/images/favicon_pen.png">
+  <script defer type="module" src="portfolio.js"></script>
 
   <meta name="author" content="Leandru Martin"/>
   <meta name="color-scheme" content="dark"/>

--- a/portfolio.js
+++ b/portfolio.js
@@ -15,8 +15,8 @@ customElements.define('portfolio-entry', PortfolioEntry)
 
 /**
  * Parses projects from the JSON and add them to the container.
- * @param projects String key of the projects in the JSON
- * @param container HTMLElement to add the projects to
+ * @param {string} projects Key of the projects in the JSON
+ * @param {HTMLElement} container Element to add the projects to
  */
 const addProjects = (projects, container) => {
   data.default[projects].forEach((project, index) => {

--- a/portfolio.js
+++ b/portfolio.js
@@ -1,0 +1,84 @@
+import * as data from './portfolio_entries.json' with {type: 'json'}
+import {StandardTemplate} from "./standardTemplate.js"
+
+class PortfolioEntry extends StandardTemplate {
+  constructor() {
+    super()
+  }
+
+  connectedCallback() {
+    super.createTemplate("portfolio-entry-template")
+  }
+}
+
+customElements.define('portfolio-entry', PortfolioEntry)
+
+/**
+ * Parses projects from the JSON and add them to the container.
+ * @param projects String key of the projects in the JSON
+ * @param container HTMLElement to add the projects to
+ */
+const addProjects = (projects, container) => {
+  data.default[projects].forEach((project, index) => {
+    const entryDiv = document.createElement("div")
+    entryDiv.classList.add("portfolio-entry")
+
+    entryDiv.innerHTML = `
+      <portfolio-entry>
+        ${project.link ?
+      `<a slot="link" href="${project.link}">${project.title}</a>` :
+      `<span slot="link">${project.title}</span>`
+    }
+        ${project.screenshot && `
+          <div slot="screenshot" class="portfolio-entry-item portfolio-screenshot opens-modal" style="display: none;">
+            <img src="${project.screenshot}"
+                 class="screenshot-img"
+                 alt=""
+                 onload="this.parentElement.style.display = 'block'"
+                 />
+          </div>
+        `}
+        ${project.description.map(paragraph => `<p slot="description">${paragraph}</p>`).join("")}
+        ${project.github && `
+          <p slot="github-link" class="github-link">
+            <a href="${project.github}"
+            >View on GitHub
+                <span class="github-link-image"></span>
+            </a>
+          </p>
+        `}
+        <ul slot="technologies" class="technologies-icons">
+        ${project.technologies
+      .map(
+        tech =>
+          `<li class="tooltip-activator tooltip-below"><img src="${tech.icon}" alt="${tech.name}" /><span class="tooltip">${tech.name}</span></li>`
+      )
+      .join("")
+    }
+        </ul>
+      </portfolio-entry>
+    `
+
+    if (index > 0) {
+      container.appendChild(document.createElement("hr"))
+    }
+    container.appendChild(entryDiv)
+  })
+}
+
+const collaborativeProjects = document.getElementById('collaborative-projects')
+addProjects("collaborativeProjects", collaborativeProjects)
+const individualProjects = document.getElementById('inserted-individual-projects')
+addProjects("individualProjects", individualProjects)
+
+document.querySelectorAll(".screenshot-img").forEach((img) => {
+  const screenshotModal = document.querySelector("#expanded-screenshot-container")
+
+  const imgElement = document.createElement("img")
+  imgElement.src = img.src
+
+  img.addEventListener("click", (e) => {
+    screenshotModal.querySelector("#expanded-screenshot").replaceChildren(imgElement)
+    screenshotModal.showModal()
+  })
+})

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 import {earnAchievement} from './achievements.js'
+import {makePositionSticky} from "./stickyPosition.js"
 
 window.addEventListener('scroll', () => {
   document.body.style.setProperty('--scroll', Math.min(0.9999, window.scrollY / window.innerHeight * 2))
@@ -7,6 +8,8 @@ window.addEventListener('scroll', () => {
     earnAchievement("scrolledToBottom")
   }
 }, false)
+
+makePositionSticky(document.querySelector("nav"), 15, "15px")
 
 const date = new Date()
 if (Math.random() < 0.1 || (date.getMonth() === 3 && date.getDate() === 1)) {

--- a/script.js
+++ b/script.js
@@ -1,11 +1,4 @@
-import * as data from './portfolio_entries.json' with {type: 'json'}
 import {earnAchievement} from './achievements.js'
-import {StandardTemplate} from "./standardTemplate.js"
-
-let searchParams = new URLSearchParams(window.location.search)
-if (searchParams.get("withAchievement") === "true") {
-  earnAchievement("visitedWithAchievement")
-}
 
 window.addEventListener('scroll', () => {
   document.body.style.setProperty('--scroll', Math.min(0.9999, window.scrollY / window.innerHeight * 2))
@@ -28,88 +21,6 @@ if (Math.random() < 0.1 || (date.getMonth() === 3 && date.getDate() === 1)) {
   `
   document.body.appendChild(cookieNotice)
 }
-
-class PortfolioEntry extends StandardTemplate {
-  constructor() {
-    super()
-  }
-
-  connectedCallback() {
-    super.createTemplate("portfolio-entry-template")
-  }
-}
-
-customElements.define('portfolio-entry', PortfolioEntry)
-
-/**
- * Parses projects from the JSON and add them to the container.
- * @param projects String key of the projects in the JSON
- * @param container HTMLElement to add the projects to
- */
-const addProjects = (projects, container) => {
-  data.default[projects].forEach((project, index) => {
-    const entryDiv = document.createElement("div")
-    entryDiv.classList.add("portfolio-entry")
-
-    entryDiv.innerHTML = `
-      <portfolio-entry>
-        ${project.link ?
-          `<a slot="link" href="${project.link}">${project.title}</a>` :
-          `<span slot="link">${project.title}</span>`
-        }
-        ${project.screenshot && `
-          <div slot="screenshot" class="portfolio-entry-item portfolio-screenshot opens-modal" style="display: none;">
-            <img src="${project.screenshot}"
-                 class="screenshot-img"
-                 alt=""
-                 onload="this.parentElement.style.display = 'block'"
-                 />
-          </div>
-        `}
-        ${project.description.map(paragraph => `<p slot="description">${paragraph}</p>`).join("")}
-        ${project.github && `
-          <p slot="github-link" class="github-link">
-            <a href="${project.github}"
-            >View on GitHub
-                <span class="github-link-image"></span>
-            </a>
-          </p>
-        `}
-        <ul slot="technologies" class="technologies-icons">
-        ${project.technologies
-          .map(
-            tech =>
-              `<li class="tooltip-activator tooltip-below"><img src="${tech.icon}" alt="${tech.name}" /><span class="tooltip">${tech.name}</span></li>`
-          )
-          .join("")
-        }
-        </ul>
-      </portfolio-entry>
-    `
-
-    if (index > 0) {
-      container.appendChild(document.createElement("hr"))
-    }
-    container.appendChild(entryDiv)
-  })
-}
-
-const collaborativeProjects = document.getElementById('collaborative-projects')
-addProjects("collaborativeProjects", collaborativeProjects)
-const individualProjects = document.getElementById('inserted-individual-projects')
-addProjects("individualProjects", individualProjects)
-
-document.querySelectorAll(".screenshot-img").forEach((img) => {
-  const screenshotModal = document.querySelector("#expanded-screenshot-container")
-
-  const imgElement = document.createElement("img")
-  imgElement.src = img.src
-
-  img.addEventListener("click", (e) => {
-    screenshotModal.querySelector("#expanded-screenshot").replaceChildren(imgElement)
-    screenshotModal.showModal()
-  })
-})
 
 window.addEventListener("deviceorientation", (event) => {
   let topLink = document.querySelector("#top-link")

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -2,9 +2,9 @@
  * Adds a scroll event listener to an element to simulate sticky positioning, having it stick to some offset off the
  * top of the screen after scrolling past a certain point.
  * @param {HTMLElement} element The element to make sticky
- * @param {int} top The offset from the top of the window, in pixels, where the element should stick
+ * @param {number} top The offset from the top of the window, in pixels, where the element should stick
  * @param {string} topRule The CSS rule to apply to the element's top property when it is in sticky mode (e.g. "15px")
- * @param {function} [topCalculationCallback] A function to recalculate the top offset when the user scrolls, if the
+ * @param [topCalculationCallback] A function to recalculate the top offset when the user scrolls, if the
  *   top offset is not constant. The function should return the new top offset in pixels.
  */
 export const makePositionSticky = (element, top, topRule, topCalculationCallback) => {

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -8,17 +8,28 @@
  *   top offset is not constant. The function should return the new top offset in pixels.
  */
 export const makePositionSticky = (element, top, topRule, topCalculationCallback) => {
-  window.addEventListener('scroll', () => {
+  let isSticky = false
+  const update = () => {
     if (topCalculationCallback) {
       top = topCalculationCallback()
     }
+
     if (element.parentElement.getBoundingClientRect().top > top) {
-      element.style.position = "absolute"
-      element.style.top = "auto"
-    } else {
+      if (isSticky) {
+        element.style.position = "absolute"
+        element.style.top = "auto"
+        isSticky = false
+      }
+    } else if (!isSticky) {
       element.style.position = "fixed"
       element.style.top = topRule
+      isSticky = true
     }
+  }
+
+  update()
+  window.addEventListener('scroll', () => {
+    update()
   }, {
     passive: true
   })

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -7,5 +7,7 @@ export const makePositionSticky = (element, top, topRule) => {
       element.style.position = "fixed"
       element.style.top = topRule
     }
-  }, false)
+  }, {
+    passive: true
+  })
 }

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -4,8 +4,8 @@
  * @param {HTMLElement} element The element to make sticky
  * @param {number} top The offset from the top of the window, in pixels, where the element should stick
  * @param {string} topRule The CSS rule to apply to the element's top property when it is in sticky mode (e.g. "15px")
- * @param [topCalculationCallback] A function to recalculate the top offset when the user scrolls, if the
- *   top offset is not constant. The function should return the new top offset in pixels.
+ * @param {function(number)} [topCalculationCallback] A function to recalculate the top offset when the user scrolls,
+ *   if the top offset is not constant. The function should return the new top offset in pixels.
  */
 export const makePositionSticky = (element, top, topRule, topCalculationCallback) => {
   let isSticky = false

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -1,12 +1,17 @@
 /**
  * Adds a scroll event listener to an element to simulate sticky positioning, having it stick to some offset off the
  * top of the screen after scrolling past a certain point.
- * @param element {HTMLElement} The element to make sticky
- * @param top {int} The offset from the top of the window, in pixels, where the element should stick
- * @param topRule {string} The CSS rule to apply to the element's top property when it is in sticky mode (e.g. "15px")
+ * @param {HTMLElement} element The element to make sticky
+ * @param {int} top The offset from the top of the window, in pixels, where the element should stick
+ * @param {string} topRule The CSS rule to apply to the element's top property when it is in sticky mode (e.g. "15px")
+ * @param {function} [topCalculationCallback] A function to recalculate the top offset when the user scrolls, if the
+ *   top offset is not constant. The function should return the new top offset in pixels.
  */
-export const makePositionSticky = (element, top, topRule) => {
+export const makePositionSticky = (element, top, topRule, topCalculationCallback) => {
   window.addEventListener('scroll', () => {
+    if (topCalculationCallback) {
+      top = topCalculationCallback()
+    }
     if (element.parentElement.getBoundingClientRect().top > top) {
       element.style.position = "absolute"
       element.style.top = "auto"

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -1,3 +1,10 @@
+/**
+ * Adds a scroll event listener to an element to simulate sticky positioning, having it stick to some offset off the
+ * top of the screen after scrolling past a certain point.
+ * @param element {HTMLElement} The element to make sticky
+ * @param top {int} The offset from the top of the window, in pixels, where the element should stick
+ * @param topRule {string} The CSS rule to apply to the element's top property when it is in sticky mode (e.g. "15px")
+ */
 export const makePositionSticky = (element, top, topRule) => {
   window.addEventListener('scroll', () => {
     if (element.parentElement.getBoundingClientRect().top > top) {

--- a/stickyPosition.js
+++ b/stickyPosition.js
@@ -1,0 +1,11 @@
+export const makePositionSticky = (element, top, topRule) => {
+  window.addEventListener('scroll', () => {
+    if (element.parentElement.getBoundingClientRect().top > top) {
+      element.style.position = "absolute"
+      element.style.top = "auto"
+    } else {
+      element.style.position = "fixed"
+      element.style.top = topRule
+    }
+  }, false)
+}

--- a/style.css
+++ b/style.css
@@ -583,7 +583,7 @@ ul.technologies-icons {
 
 #achievements-pane {
   --button-width: 2.7rem;
-  --pane-border: 2px; /*From .overlay*/
+  --pane-border: var(--overlay-border-size);
   --pane-margin: 20px;
 
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -245,9 +245,7 @@ hr {
 }
 
 nav {
-  position: sticky;
   z-index: 2;
-  top: 15px;
 
   margin: 0 20px;
 
@@ -590,6 +588,7 @@ ul.technologies-icons {
 
   box-sizing: border-box;
   margin: var(--pane-margin);
+  /*margin-top: 0;*/
   height: 75vh;
 
   button {

--- a/style.css
+++ b/style.css
@@ -247,7 +247,10 @@ hr {
 nav {
   z-index: 2;
 
-  margin: 0 20px;
+  margin: 0;
+
+  left: 20px;
+  right: 20px;
 
   ul {
     justify-content: space-around;
@@ -735,6 +738,10 @@ ul.technologies-icons {
   #bio {
     margin: 10%;
     padding: 5%;
+  }
+
+  #post-nav-spacer {
+    height: 68px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -245,10 +245,11 @@ hr {
 }
 
 nav {
+  position: absolute;
   z-index: 2;
 
   margin: 0;
-
+  top: auto;
   left: 20px;
   right: 20px;
 
@@ -580,7 +581,9 @@ ul.technologies-icons {
   --pane-border: 2px; /*From .overlay*/
   --pane-margin: 20px;
 
+  position: absolute;
   z-index: 3;
+  top: auto;
   left: 0;
   right: 0;
   transform: translateX(calc(-100% + var(--button-width) + var(--pane-border) - var(--pane-margin)));
@@ -591,7 +594,6 @@ ul.technologies-icons {
 
   box-sizing: border-box;
   margin: var(--pane-margin);
-  /*margin-top: 0;*/
   height: 75vh;
 
   button {

--- a/style.css
+++ b/style.css
@@ -26,6 +26,11 @@ https://9elements.com/css-rule-order/
   --shadow-sm: var(--shadow-color) var(--shadow-size-sm), inset var(--shadow-color) var(--shadow-size-sm);
 
   --transition-speed-main: 200ms;
+
+  --overlay-border-size: 2px;
+  --nav-ul-margin-size: 12px;
+  --nav-item-height: 20px;
+  --nav-item-padding: 10px;
 }
 
 html {
@@ -258,7 +263,7 @@ nav {
 
     display: flex;
 
-    margin: 12px;
+    margin: var(--nav-ul-margin-size);
 
     list-style: none;
 
@@ -269,8 +274,8 @@ nav {
       display: flex;
 
       border-radius: 100px;
-      height: 20px;
-      padding: 10px;
+      height: var(--nav-item-height);
+      padding: var(--nav-item-padding);
 
       background-color: inherit !important;
       /*backdrop-filter: inherit;*/
@@ -458,7 +463,7 @@ ul.technologies-icons {
 }
 
 .overlay {
-  border: 2px solid rgb(96, 64, 96);
+  border: var(--overlay-border-size) solid rgb(96, 64, 96);
   box-shadow: var(--shadow-md);
   border-radius: var(--border-radius-md);
 
@@ -743,7 +748,7 @@ ul.technologies-icons {
   }
 
   #post-nav-spacer {
-    height: 68px;
+    height: calc(var(--overlay-border-size) * 2 + var(--nav-ul-margin-size) * 2 + var(--nav-item-height) + var(--nav-item-padding) * 2);
   }
 }
 
@@ -753,7 +758,7 @@ ul.technologies-icons {
   }
 }
 
-@media (max-width: 750px) {
+@media (max-width: 749px) {
   h2 {
     top: 15px;
     margin-left: auto;


### PR DESCRIPTION
Navbar position is no longer sticky. Instead, it simulates sticky positioning, so that expanding the navbar on a sub-750px wide screen no longer makes the content below it jump down, because it is now removed from the content flow.